### PR TITLE
allow relative paths for cql file script

### DIFF
--- a/src/main/scala/com/github/hochgi/sbt/cassandra/CassandraPlugin.scala
+++ b/src/main/scala/com/github/hochgi/sbt/cassandra/CassandraPlugin.scala
@@ -208,7 +208,9 @@ object CassandraPlugin extends Plugin {
 			Process(args,cassHome).!
 		}
 		else if(cql != defaultCqlInit) {
-			val bin = cassHome / "bin" / "cqlsh"
+            val bin = cassHome / "bin" / "cqlsh"
+            val cqlPath = new File(cql).getAbsolutePath
+            val args = Seq(bin.getAbsolutePath, "-f", cqlPath,host,cqlPort)
 			val args = Seq(bin.getAbsolutePath, "-f", cql,host,cqlPort)
 			Process(args,cassHome).!
 		}


### PR DESCRIPTION
Right now you use "Process" command to execute cqlsh and provie a file with "-f" parameter.
But you also supply current working directory which is set to where cassandra is.
This makes it hard to provide relative path for cql script.
