### PR TITLE
version 0.6 released and timeout on startCassandr

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ to change cassandra rpc port (note: even if you change the port on the configura
 ```scala
 cassandraPort := "PORT_NUMBER"
 ```
-timeout for waiting on cassandra to start can be configured with property:
+timeout for waiting on cassandra to start (default is 20 seconds) can be configured with property (in seconds):
 ```scala
 cassandraStartDeadline := 10
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ organization := "com.github.hochgi"
 
 name := "sbt-cassandra-plugin"
 
+description := "SBT plugin to allow launching Cassandra during tests, and test your application against it"
+
 version := "0.5"
 
 scalaVersion := "2.10.4"
@@ -17,3 +19,38 @@ libraryDependencies ++= Seq("org.apache.thrift" % "libthrift" % "0.9.2",
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:postfixOps")
 
 externalDependencyClasspath in Compile ~= (_.filterNot(_.data.toString.contains("commons-logging")))
+
+
+publishTo <<= version { v: String =>
+  val nexus = "https://oss.sonatype.org/"
+  if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
+  else                             Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
+
+publishMavenStyle := true
+
+publishArtifact in Test := false
+
+pomIncludeRepository := { x => false }
+
+pomExtra := (
+  <url>http://github.com/hochgi/sbt-cassandra-plugin</url>
+  <licenses>
+    <license>
+      <name>The MIT License (MIT)</name>
+      <url>http://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>git@github.com:kpbochenek/sbt-cassandra-plugin.git</url>
+    <connection>scm:git:git@github.com:kpbochenek/sbt-cassandra-plugin.git</connection>
+  </scm>
+  <developers>
+    <developer>
+      <id>hochgi</id>
+      <name>Thomson Reuters</name>
+      <url>https://github.com/hochgi</url>
+      </developer>
+  </developers>
+)

--- a/src/main/scala/com/github/hochgi/sbt/cassandra/CassandraPlugin.scala
+++ b/src/main/scala/com/github/hochgi/sbt/cassandra/CassandraPlugin.scala
@@ -200,21 +200,20 @@ object CassandraPlugin extends Plugin {
 			if (tr.isOpen) tr.close
 		}
 	}
-	def initCassandra(cli: String, cql: String, classpath: String, cassHome: File, host: String, port: String, cqlPort: String): Unit = {
-		if(cli != defaultCliInit && cql != defaultCqlInit) sys.error("use cli initiation commands, or cql initiation commands, but not both!")
-		else if(cli != defaultCliInit) {
-			val bin = cassHome / "bin" / "cassandra-cli"
-			val args = Seq(bin.getAbsolutePath, "-f", cli,"-h",host,"-p",port)
-			Process(args,cassHome).!
-		}
-		else if(cql != defaultCqlInit) {
-            val bin = cassHome / "bin" / "cqlsh"
-            val cqlPath = new File(cql).getAbsolutePath
-            val args = Seq(bin.getAbsolutePath, "-f", cqlPath,host,cqlPort)
-			val args = Seq(bin.getAbsolutePath, "-f", cql,host,cqlPort)
-			Process(args,cassHome).!
-		}
-	}
+  def initCassandra(cli: String, cql: String, classpath: String, cassHome: File, host: String, port: String, cqlPort: String): Unit = {
+    if(cli != defaultCliInit && cql != defaultCqlInit) {
+      sys.error("use cli initiation commands, or cql initiation commands, but not both!")
+    } else if(cli != defaultCliInit) {
+      val bin = cassHome / "bin" / "cassandra-cli"
+      val args = Seq(bin.getAbsolutePath, "-f", cli,"-h",host,"-p",port)
+      Process(args,cassHome).!
+    } else if(cql != defaultCqlInit) {
+      val bin = cassHome / "bin" / "cqlsh"
+      val cqlPath = new File(cql).getAbsolutePath
+      val args = Seq(bin.getAbsolutePath, "-f", cqlPath,host,cqlPort)
+      Process(args,cassHome).!
+    }
+  }
 
   def overrideConfigs(confDir: String, confMappings:  Seq[(String,java.lang.Object)], logger: Logger): Unit = {
     val cassandraYamlPath = s"$confDir/cassandra.yaml"


### PR DESCRIPTION
Version bumped to 0.6 and released on oss.sonatype.com
This allows to include in project as normal dependency.

Also added timeout to wait for starting cassandra.
When something goes wrong during starting cassandra(i.e. path was typed wrong) sbt should not hang forever.